### PR TITLE
Make the client have its own sendPacket

### DIFF
--- a/server/service/gitutils.go
+++ b/server/service/gitutils.go
@@ -271,15 +271,6 @@ func possiblyFlush(w io.Writer) {
 	}
 }
 
-// SendPacketWithFlush sends a single git packet without sideband identifier and a
-// flush packet.
-func SendPacketWithFlush(w io.Writer, packet []byte) error {
-	if err := sendPacket(w, packet); err != nil {
-		return err
-	}
-	return sendFlushPacket(w)
-}
-
 func sendPacket(w io.Writer, packet []byte) error {
 	len, err := getPacketLen(packet)
 	if err != nil {


### PR DESCRIPTION
This means that it gets way smaller dependency trees.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>