### PR TITLE
Make sure that the state is not readable

### DIFF
--- a/server/service/statestore.go
+++ b/server/service/statestore.go
@@ -242,7 +242,7 @@ func (store *stateStore) Save() error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(path.Join(store.directory, "state.json"), cts, 0644)
+	err = ioutil.WriteFile(path.Join(store.directory, "state.json"), cts, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
From a cursory reading, state.json contain a marshalled
json dump of a stateStore object. In turn, this marshall
a Service object in cfg, which marshall the ServerCerts
array, which contains the TLS certicates, and the key.

See ./server/cmd/serve.go

Signed-off-by: Michael Scherer <misc@redhat.com>