### PR TITLE
Implement metatest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: go
 # We modify /etc/hosts
 sudo: true
+git:
+  # We need the full repo for the metatest
+  depth: false
 go:
 - "1.10"
 - master

--- a/functional_tests/base.go
+++ b/functional_tests/base.go
@@ -285,6 +285,14 @@ func cloneCmdHTTPS(t *testing.T, node nodeNrType, reponame, username string) (cm
 }
 
 func clone(t *testing.T, method cloneMethod, node nodeNrType, reponame, username string, expectSuccess bool) string {
+	return _clone(t, method, node, reponame, username, expectSuccess, false)
+}
+
+func cloneBare(t *testing.T, method cloneMethod, node nodeNrType, reponame, username string, expectSuccess bool) string {
+	return _clone(t, method, node, reponame, username, expectSuccess, true)
+}
+
+func _clone(t *testing.T, method cloneMethod, node nodeNrType, reponame, username string, expectSuccess bool, bare bool) string {
 	ourdir, err := ioutil.TempDir(cloneDir, fmt.Sprintf("clone_%s_%s_", reponame, username))
 	failIfErr(t, err, "creating clone directory")
 
@@ -300,6 +308,9 @@ func clone(t *testing.T, method cloneMethod, node nodeNrType, reponame, username
 		t.Fatal("Unknown clone method", method)
 	}
 	cmd = append(cmd, ourdir)
+	if bare {
+		cmd = append(cmd, "--bare")
+	}
 
 	if !expectSuccess {
 		runFailingRawCommand(t, "git", "", envupdates, cmd...)

--- a/functional_tests/meta_test.go
+++ b/functional_tests/meta_test.go
@@ -1,0 +1,53 @@
+package functional_tests
+
+import (
+	"strings"
+	"testing"
+)
+
+// The most Meta test ever: pushing ourselves to a repoSpanner cluster!
+func TestMeta(t *testing.T) {
+	runForTestedCloneMethods(t, performMetaTest)
+}
+
+func performMetaTest(t *testing.T, method cloneMethod) {
+	defer testCleanup(t)
+	nodea := nodeNrType(1)
+	//nodeb := nodeNrType(2)
+	//nodec := nodeNrType(3)
+
+	createNodes(t, nodea) //, nodeb, nodec)
+
+	createRepo(t, nodea, "repoSpanner", true)
+
+	// Determine the repoSpanner repo main directory
+	repodir := runRawCommand(t, "git", "", nil, "rev-parse", "--show-toplevel")
+	repodir = strings.Trim(repodir, "\n")
+
+	// Get the master ref
+	masterref := runRawCommand(t, "git", repodir, nil, "rev-parse", "master")
+
+	// Create a repo that's cloned so it's setup
+	wdir1 := cloneBare(t, method, nodea, "repoSpanner", "admin", true)
+
+	// Push the main repoSpanner repo to the cloned repo
+	pushout := runRawCommand(t, "git", repodir, nil, "push", wdir1, "--mirror")
+	if !strings.Contains(pushout, "* [new branch]      master -> master") {
+		t.Fatal("Something went wrong in pushing to local")
+	}
+
+	// Push
+	pushout = runRawCommand(t, "git", wdir1, nil, "push", "--all")
+	if !strings.Contains(pushout, "* [new branch]      master -> master") {
+		t.Fatal("Something went wrong in pushing to cluster")
+	}
+
+	// And reclone
+	wdir2 := clone(t, method, nodea, "repoSpanner", "admin", true)
+	clonedmasterref := runRawCommand(t, "git", wdir2, nil, "rev-parse", "master")
+
+	// And check
+	if masterref != clonedmasterref {
+		t.Errorf("Master ref (%s) does not equal cloned master ref (%s)", masterref, clonedmasterref)
+	}
+}


### PR DESCRIPTION
This implements a test where the repoSpanner working repository is pushed to a running instance of repoSpanner.
This is a perfect example of a real-life repository.