### PR TITLE
Add group write by default to all files written

### DIFF
--- a/server/service/clustered_storage.go
+++ b/server/service/clustered_storage.go
@@ -336,7 +336,7 @@ func (d *clusterStorageProjectPushDriverInstance) runPeerSyncer(peerid uint64) {
 
 			if retryfile == nil {
 				if _, err := os.Stat(retrydir); os.IsNotExist(err) {
-					err := os.MkdirAll(retrydir, 0755)
+					err := os.MkdirAll(retrydir, 0775)
 					if err != nil {
 						mylog.WithError(err).Info("Error creating retry dir")
 						break

--- a/server/service/raft.go
+++ b/server/service/raft.go
@@ -187,7 +187,7 @@ func (rc *stateRaftNode) loadSnapshot() *raftpb.Snapshot {
 
 func (rc *stateRaftNode) openWAL(snapshot *raftpb.Snapshot) *wal.WAL {
 	if !wal.Exist(rc.waldir) {
-		if err := os.Mkdir(rc.waldir, 0750); err != nil {
+		if err := os.Mkdir(rc.waldir, 0770); err != nil {
 			log.Fatalf("cannot create dir for wal (%v)", err)
 		}
 
@@ -257,7 +257,7 @@ func (rc *stateRaftNode) writeError(err error) {
 
 func (rc *stateRaftNode) startRaft(startedC chan<- struct{}) {
 	if !fileutil.Exist(rc.snapdir) {
-		if err := os.Mkdir(rc.snapdir, 0750); err != nil {
+		if err := os.Mkdir(rc.snapdir, 0770); err != nil {
 			log.Fatalf("cannot create dir for snapshot (%v)", err)
 		}
 	}

--- a/server/service/statestore.go
+++ b/server/service/statestore.go
@@ -131,16 +131,16 @@ func (cfg *Service) loadStateStore(spawning bool, joinnode string, directory str
 			return
 		}
 		cfg.log.Info("No state existed, initializing")
-		if err = os.MkdirAll(store.directory, 0755); err != nil {
+		if err = os.MkdirAll(store.directory, 0775); err != nil {
 			return
 		}
-		if err = os.MkdirAll(path.Join(store.directory, "async-outqueues"), 0755); err != nil {
+		if err = os.MkdirAll(path.Join(store.directory, "async-outqueues"), 0775); err != nil {
 			return
 		}
-		if err = os.MkdirAll(path.Join(store.directory, "repoinfos"), 0755); err != nil {
+		if err = os.MkdirAll(path.Join(store.directory, "repoinfos"), 0775); err != nil {
 			return
 		}
-		if err = os.MkdirAll(path.Join(store.directory, "objectsyncs"), 0755); err != nil {
+		if err = os.MkdirAll(path.Join(store.directory, "objectsyncs"), 0775); err != nil {
 			return
 		}
 
@@ -255,7 +255,7 @@ func (store *stateStore) Save() error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(path.Join(store.directory, "state.json"), cts, 0600)
+	err = ioutil.WriteFile(path.Join(store.directory, "state.json"), cts, 0660)
 	if err != nil {
 		return err
 	}

--- a/server/storage/tree.go
+++ b/server/storage/tree.go
@@ -222,7 +222,7 @@ func (t *treeStorageProjectPushDriverInstance) StageObject(objtype ObjectType, o
 	f, err := ioutil.TempFile(t.t.t.dirname, t.t.p+"_stage_")
 	if os.IsNotExist(err) {
 		// Seems the project folder didn't exist yet, create it
-		err = os.MkdirAll(path.Join(t.t.t.dirname, t.t.p), 0755)
+		err = os.MkdirAll(path.Join(t.t.t.dirname, t.t.p), 0775)
 		if err != nil {
 			return nil, err
 		}
@@ -273,7 +273,7 @@ func (t *treeStorageProjectDriverStagedObject) Finalize(objid ObjectID) (ObjectI
 		// File did not yet exist, write it
 		err := os.Rename(t.f.Name(), t.p.getObjPath(calced))
 		if os.IsNotExist(err) {
-			err = os.MkdirAll(path.Dir(destpath), 0755)
+			err = os.MkdirAll(path.Dir(destpath), 0775)
 			if err != nil {
 				return ZeroID, err
 			}


### PR DESCRIPTION
This makes us depend on the umask for files to be secure against the user group.

Fixes: #31
Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>