### PR TITLE
Allow overriding bridge CA and baseurl from environment

### DIFF
--- a/bridge/root.go
+++ b/bridge/root.go
@@ -132,9 +132,17 @@ func isRawGitRepo(path string) (rawgit bool, rsname string, err error) {
 	return
 }
 
+func loadURLAndCAFromEnv(allenv bool) {
+	if allenv || configuration.BaseURL == ":FROMENV:" {
+		configuration.BaseURL = os.Getenv("REPOBRIDGE_BASEURL")
+	}
+	if allenv || configuration.Ca == ":FROMENV:" {
+		configuration.Ca = os.Getenv("REPOBRIDGE_CA")
+	}
+}
+
 func loadConfigFromEnv() {
-	configuration.BaseURL = os.Getenv("REPOBRIDGE_BASEURL")
-	configuration.Ca = os.Getenv("REPOBRIDGE_CA")
+	loadURLAndCAFromEnv(true)
 	configuration.Certs = make(map[string]map[string]string)
 	configuration.Certs["_default_"] = make(map[string]string)
 	configuration.Certs["_default_"]["cert"] = os.Getenv("REPOBRIDGE_CERT")
@@ -153,6 +161,8 @@ func loadConfig() {
 		checkError(err, "Error reading configuration")
 		err = json.Unmarshal(cts, &configuration)
 		checkError(err, "Error parsing configuration")
+
+		loadURLAndCAFromEnv(false)
 	}
 
 	if configuration.Extras == nil {


### PR DESCRIPTION
The bridge needs to use as little implicit behavior as possible, as such
we don't want to automatically load everything from environment unless the
calling application says it will take full control.
However, it seems people want to be able to override just the BaseURL
from environment, so let's add a special :FROMENV: configuration value to
allow for that if explicitly configured.

Fixes: #34
Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>