### PR TITLE
Use request context for reqctx

### DIFF
--- a/server/service/httpcontext.go
+++ b/server/service/httpcontext.go
@@ -66,7 +66,7 @@ func addHTTPHeaderInfo(reqlogger *logrus.Entry, r *http.Request) *logrus.Entry {
 }
 
 func (cfg *Service) ctxFromReq(w http.ResponseWriter, r *http.Request, server string) context.Context {
-	ctx := context.Background()
+	ctx := r.Context()
 
 	ctx = watchCloser(ctx, w)
 


### PR DESCRIPTION
This will fix a bug where the watchcloser doesn't realize the context terminates,
and makes sure other parts using the context know to close off after request.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>