### PR TITLE
The non-blocking hook tests announces itself

### DIFF
--- a/functional_tests/blobs/test.sh
+++ b/functional_tests/blobs/test.sh
@@ -10,3 +10,4 @@ cat </dev/stdin
 echo "STDIN DONE"
 echo "LS /"
 ls /
+echo "THIS IS THE NON-BLOCKING HOOK"


### PR DESCRIPTION
I've been investigating a test that occasionally fails, and I've
observed that it seems that the non-blocking hook script may be
getting executed when the blocking one is expected. This commit
adds an echo to the non-blocking hook test script so that it
announces itself, making it easier to identify in the test
output.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>