### PR TITLE
Refactor dbGetNextObject() to return more than one object

### DIFF
--- a/server/service/clustered_storage.go
+++ b/server/service/clustered_storage.go
@@ -463,6 +463,8 @@ func (d *clusterStorageProjectPushDriverInstance) dbAddObject(objid storage.Obje
 	return err
 }
 
+// Retrieve a list of ObjectIDs that need to be synced with the node identified by the given nodeid.
+// The object IDs will be retrieved from the node's database table, deleted, and then returned.
 func (d *clusterStorageProjectPushDriverInstance) dbGetNextObjects(nodeid uint64) ([]storage.ObjectID, error) {
 	if d.hasFailed {
 		return []storage.ObjectID{storage.ZeroID}, errors.New("Object sync has already failed")


### PR DESCRIPTION
I did some performance profiling during the "Writing objects"
phase of a git push, and I found that about 20% of the time was
spent in dbGetNextObject(). After examining the function, I noted
that it was fetching one object and was spending a lot of its time
in the SELECT statement.

This commit renames that function to dbGetNextObjects(), and as
the rename implies, it now returns a slice of ObjectIDs instead of
a single ObjectID. This means the function gets called many fewer
times, and that we issue many fewer queries to the database.

The program went from spending 20.45% of its time in this function
to 1.22%, an improvement of 16.8%.

I tested this by pushing up the source code from Fedora's bodhi
project. The overall push went from taking 3504 seconds to 1716
seconds, a 51.03% improvement.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>