### PR TITLE
Ansible: Provide a way to pass build flags

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -26,6 +26,7 @@ settings pertain to customizing the build or installation.
 * ```repospanner_version``` (str) - Which git ref to install. Defaults to ```"master"```.
 * ```repospanner_build_deps``` (seq of str) - A list of build dependencies for building repoSpanner
   on each node. Defaults to ```["golang"]```.
+* ```repospanner_build_flags``` (str) - Flags to pass to repoSpanner's ```build.sh```. Defaults to ```""```.
 * ```repospanner_clone_path``` (str) - A filesystem path in which to clone the repoSpanner sources.
   Defaults to ```"/tmp/repospanner"```.
 

--- a/ansible/defaults/main.yml
+++ b/ansible/defaults/main.yml
@@ -4,6 +4,8 @@
 # A list of build dependencies needed for repospanner
 repospanner_build_deps:
   - golang
+# Flags to pass to repospanner's build.sh
+repospanner_build_flags: ""
 # Where to clone the repo to
 repospanner_clone_path: /tmp/repospanner
 # Where to install repospanner (it will go into a bin/ folder inside this path, so by default it

--- a/ansible/roles/install/tasks/main.yml
+++ b/ansible/roles/install/tasks/main.yml
@@ -20,7 +20,7 @@
         version: "{{ repospanner_version }}"
 
     - name: Build repospanner
-      command: "{{ repospanner_clone_path }}/build.sh"
+      command: "{{ repospanner_clone_path }}/build.sh {{ repospanner_build_flags }}"
       args:
         chdir: "{{ repospanner_clone_path }}"
 


### PR DESCRIPTION
This adds a repospanner_build_flags variable to the Ansible roles
so that users can add their own build flags.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>